### PR TITLE
Allow mods to use existing DX11-Present hook

### DIFF
--- a/ExampleMod/ExampleMod.cpp
+++ b/ExampleMod/ExampleMod.cpp
@@ -45,6 +45,10 @@ void ExampleMod::PostBeginPlay(std::wstring ModActorName, UE4::AActor* Actor)
 	}
 }
 
+void ExampleMod::DX11Present(ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRenderTargetView)
+{
+}
+
 void ExampleMod::OnModMenuButtonPressed()
 {
 }

--- a/ExampleMod/ExampleMod.h
+++ b/ExampleMod/ExampleMod.h
@@ -31,6 +31,9 @@ public:
 	//PostBeginPlay of EVERY Blueprint ModActor
 	virtual void PostBeginPlay(std::wstring ModActorName, UE4::AActor* Actor) override;
 
+	//DX11 hook for when an image will be presented to the screen
+	virtual void DX11Present(ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRenderTargetView) override;
+
 	virtual void OnModMenuButtonPressed() override;
 
 	//Call ImGui Here (CALLED EVERY FRAME ON DX HOOK)

--- a/UnrealEngineModLoader/LoaderUI.cpp
+++ b/UnrealEngineModLoader/LoaderUI.cpp
@@ -413,7 +413,10 @@ void LoaderUI::LoaderD3D11Present(IDXGISwapChain* pSwapChain, UINT SyncInterval,
 HRESULT(*D3D11Present)(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags);
 HRESULT __stdcall hookD3D11Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags)
 {
-	LoaderUI::GetUI()->LoaderD3D11Present(pSwapChain, SyncInterval, Flags);
+	// LoaderUI initializes D3D objects, mods can then use those objects for drawing, hardware access, etc.
+	LoaderUI* UI = LoaderUI::GetUI();
+	UI->LoaderD3D11Present(pSwapChain, SyncInterval, Flags);
+	Global::GetGlobals()->eventSystem.dispatchEvent("DX11Present", UI->pDevice, UI->pContext, UI->pRenderTargetView);
 	return D3D11Present(pSwapChain, SyncInterval, Flags);
 }
 

--- a/UnrealEngineModLoader/UnrealEngineModLoader/Mod/Mod.cpp
+++ b/UnrealEngineModLoader/UnrealEngineModLoader/Mod/Mod.cpp
@@ -25,6 +25,11 @@ namespace CallBackHandler
 	{
 		Mod::ModRef->PostBeginPlay(ModActorName, Actor);
 	}
+
+	void CallBackDX11Present(ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRenderTargetView)
+	{
+		Mod::ModRef->DX11Present(pDevice, pContext, pRenderTargetView);
+	}
 }
 
 void Mod::InitGameState()
@@ -43,6 +48,10 @@ void Mod::PostBeginPlay(std::wstring ModActorName, UE4::AActor* Actor)
 {
 }
 
+void Mod::DX11Present(ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRenderTargetView)
+{
+}
+
 void Mod::DrawImGui()
 {
 }
@@ -53,6 +62,7 @@ void Mod::SetupHooks()
 	Global::GetGlobals()->eventSystem.registerEvent(new Event<>("InitGameState", &CallBackHandler::CallBackInitGameState));
 	Global::GetGlobals()->eventSystem.registerEvent(new Event<std::wstring, UE4::AActor*>("PostBeginPlay", &CallBackHandler::CallBackPostBeginPlay));
 	Global::GetGlobals()->eventSystem.registerEvent(new Event<>("DrawImGui", &CallBackHandler::CallBackDrawImGui));
+	Global::GetGlobals()->eventSystem.registerEvent(new Event<ID3D11Device*, ID3D11DeviceContext*, ID3D11RenderTargetView*>("DX11Present", &CallBackHandler::CallBackDX11Present));
 }
 
 void Mod::CompleteModCreation()

--- a/UnrealEngineModLoader/UnrealEngineModLoader/Mod/Mod.h
+++ b/UnrealEngineModLoader/UnrealEngineModLoader/Mod/Mod.h
@@ -41,6 +41,9 @@ public:
 	//PostBeginPlay of EVERY Blueprint ModActor
 	virtual void PostBeginPlay(std::wstring ModActorName, UE4::AActor* Actor);
 
+	//DX11 hook for when an image will be presented to the screen
+	virtual void DX11Present(ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRenderTargetView);
+
 	virtual void OnModMenuButtonPressed();
 
 	//Called When Mod Construct Finishes


### PR DESCRIPTION
TLDR: Adds a mod event that is called whenever a frame will be presented via DX11

I'm in the process of writing a VR mod for Ghostrunner using UnrealModLoader, and I needed to hook into DX11. I was implementing my own DX11 hooks, but then I found yours in LoaderUI. This PR allows any mod to use the existing DX11 resources, which removes any mod DX11 initialization like creating a Device/SwapChain/Context and hooking into Present.

This change works by adding an event dispatcher at the existing DX11 Present detour, which then calls any mods that have registered with that event, passing the Device/Context/RenderTargetView.

I'm currently using these changes in a custom build of UML and have tested them by doing basic operations on the resources (creating more RenderTargetViews for VR, for example).