### PR TITLE
Concurrent logging

### DIFF
--- a/UnrealEngineModLoader/UnrealEngineModLoader/Utilities/Logger.cpp
+++ b/UnrealEngineModLoader/UnrealEngineModLoader/Utilities/Logger.cpp
@@ -1,3 +1,4 @@
 #include "Logger.h"
 
+std::mutex Log::mtx;
 std::vector<std::string> Log::LogArray;

--- a/UnrealEngineModLoader/UnrealEngineModLoader/Utilities/Logger.h
+++ b/UnrealEngineModLoader/UnrealEngineModLoader/Utilities/Logger.h
@@ -2,6 +2,7 @@
 #include <windows.h>
 #include <vector>
 #include <string>
+#include <mutex>
 
 #include "../UMLDefs.h"
 
@@ -22,6 +23,8 @@ private:
 	template <typename ...Args>
 	static void LogMsg(MsgType type, const std::string& format, Args&& ...args)
 	{
+		std::lock_guard guard(mtx);
+		
 		HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
 		fprintf(LOG_STREAM, "[");
@@ -109,5 +112,6 @@ public:
 	}
 
 private:
+	static std::mutex mtx;
 	static std::vector<std::string> LogArray;
 };


### PR DESCRIPTION
If two threads tried to write to the log at the same time, the log output was jumbled (a mix of both lines at once), and the file might not have been available to write if another thread was using it, causing the entire process to crash. This is a small fix for that race condition.

I don't know which branch to merge to, so let me know if it should go to a different one, and I can recreate the pull request.